### PR TITLE
Inline DI annotation to support minification

### DIFF
--- a/src/nya-bootstrap-select.js
+++ b/src/nya-bootstrap-select.js
@@ -7,7 +7,7 @@
 'use strict';
 
 angular.module('nya.bootstrap.select',[])
-  .directive('nyaSelectpicker', function ($parse) {
+  .directive('nyaSelectpicker', ['$parse', function ($parse) {
 
     // NG_OPTIONS_REGEXP copy from angular.js select directive
     var NG_OPTIONS_REGEXP = /^\s*([\s\S]+?)(?:\s+as\s+([\s\S]+?))?(?:\s+group\s+by\s+([\s\S]+?))?\s+for\s+(?:([\$\w][\$\w]*)|(?:\(\s*([\$\w][\$\w]*)\s*,\s*([\$\w][\$\w]*)\s*\)))\s+in\s+([\s\S]+?)(?:\s+track\s+by\s+([\s\S]+?))?$/;
@@ -204,4 +204,4 @@ angular.module('nya.bootstrap.select',[])
 
       }
     };
-  });
+  }]);


### PR DESCRIPTION
Implicit dependencies cause the directive to break when minified. Adding the inline dependency annotation fixes this.
