### PR TITLE
Performance: Adjust $watch statement so it does not run every $digest

### DIFF
--- a/src/nya-bootstrap-select.js
+++ b/src/nya-bootstrap-select.js
@@ -46,6 +46,8 @@ angular.module('nya.bootstrap.select',[])
           angular.forEach(BS_ATTR, function(attr) {
             selectorOptions[attr] = attrs[attr];
           });
+
+          return selectorOptions;
         };
 
         /**
@@ -119,7 +121,8 @@ angular.module('nya.bootstrap.select',[])
           // This is slow, but not as slow as calling optionDOMWatch every $digest
           return {
             ngModel: ngCtrl.$viewValue,
-            options: makeOptionArray( $(element).find('option') )
+            options: makeOptionArray( $(element).find('option') ),
+            selectors: updateSelectorOptions()
           };
         // If any of the above properties change, call optionDOMWatch.
         }, optionDOMWatch, true);


### PR DESCRIPTION
This optimization will increase performance. However, we need to make sure it's watching every property type the directive is concerned with. Otherwise, something in the application may update and the select will not be notified to change.
