### PR TITLE
feat: add IIFE to keep reference to the first loaded jQuery

### DIFF
--- a/src/nya-bootstrap-select.js
+++ b/src/nya-bootstrap-select.js
@@ -9,8 +9,6 @@
   
   angular.module('nya.bootstrap.select',[])
     .directive('nyaSelectpicker', ['$parse', function ($parse) {
-      var $ = angular.element;
-      
       // NG_OPTIONS_REGEXP copy from angular.js select directive
       var NG_OPTIONS_REGEXP = /^\s*([\s\S]+?)(?:\s+as\s+([\s\S]+?))?(?:\s+group\s+by\s+([\s\S]+?))?\s+for\s+(?:([\$\w][\$\w]*)|(?:\(\s*([\$\w][\$\w]*)\s*,\s*([\$\w][\$\w]*)\s*\)))\s+in\s+([\s\S]+?)(?:\s+track\s+by\s+([\s\S]+?))?$/;
       return {


### PR DESCRIPTION
Add IIFE to keep reference to the first loaded jQuery in order to avoid issues with old references.
I've some issues with this, and it's a common pattern in JavaScript plugins development

Additionally, 'use strict' statement is now inside the closure, so it's better to prevent to use it from global scope in the case that the user concatenates the library with orders, that's usually normal in minification processes
