### PR TITLE
FIXED: live-search keeps selected the first match item

### DIFF
--- a/src/nya-bs-select.js
+++ b/src/nya-bs-select.js
@@ -635,7 +635,8 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', 'nyaBsC
 
           // focus on selected element
           for(var i = 0; i < dropdownMenu.children().length; i++) {
-            if(dropdownMenu.children().eq(i).hasClass('selected')) {
+            var childElement = dropdownMenu.children().eq(i); 
+            if (!childElement.hasClass('not-match') && childElement.hasClass('selected')) {
               return dropdownMenu.children().eq(i)[0];
             }
           }


### PR DESCRIPTION
I've fixed the issue I reported earlier today on your control. Please review and include if you think it's the right fix. 

Thanks!
Erlis 