### PR TITLE
Support changing locale on the fly

### DIFF
--- a/src/nya-bs-config.js
+++ b/src/nya-bs-config.js
@@ -4,6 +4,7 @@
 nyaBsSelect.provider('nyaBsConfig', function() {
 
   var locale = null;
+  var _self = this;
 
   // default localized text. cannot be modified.
   var defaultText = {
@@ -56,7 +57,10 @@ nyaBsSelect.provider('nyaBsConfig', function() {
     if(!localizedText) {
       localizedText = defaultText['en-us'];
     }
-    return localizedText;
+    return { 
+      text: localizedText, 
+      use: useLocale 
+    };
   }];
 
 });

--- a/src/nya-bs-select.js
+++ b/src/nya-bs-select.js
@@ -68,7 +68,7 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', 'nyaBsC
         length,
         index,
         liElement,
-        localizedText = nyaBsConfig,
+        localizedText = nyaBsConfig.text,
         isMultiple = typeof tAttrs.multiple !== 'undefined',
         nyaBsOptionValue;
 


### PR DESCRIPTION
Usage: 
```
nyaBsConfig.use('en')
```

Its a no brainer.