### PR TITLE
Compiling content of the button before appending it

### DIFF
--- a/src/nya-bs-select.js
+++ b/src/nya-bs-select.js
@@ -880,6 +880,7 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
                 length = bsOptionElements.length,
                 optionTitle,
                 selection = [],
+                optionScopes = [],
                 match,
                 count,
                 clone;
@@ -919,6 +920,7 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
                         selection.push(document.createTextNode(optionTitle));
                       } else {
                         selection.push(getOptionText(nyaBsOption));
+                        optionScopes.push(nyaBsOption.data('isolateScope'))
                       }
 
                     }
@@ -929,6 +931,7 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
                         selection.push(document.createTextNode(optionTitle));
                       } else {
                         selection.push(getOptionText(nyaBsOption));
+                        optionScopes.push(nyaBsOption.data('isolateScope'))
                       }
                     }
                   }
@@ -943,13 +946,13 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
                 dropdownToggle.removeClass('show-special-title');
                 // either single or multiple selection will show the only selected content.
                 filterOption.empty();
-                clone = $compile (selection[0])($scope);
+                clone = $compile (selection[0])(optionScopes[0]);
                 filterOption.append(clone);
               } else {
                 dropdownToggle.removeClass('show-special-title');
                 filterOption.empty();
                 for(index = 0; index < selection.length; index++) {
-                  clone = $compile (selection[index])($scope);
+                  clone = $compile (selection[index])(optionScopes[index]);
                   filterOption.append(clone);
                   if(index < selection.length -1) {
                     filterOption.append(document.createTextNode(', '));

--- a/src/nya-bs-select.js
+++ b/src/nya-bs-select.js
@@ -881,7 +881,8 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
                 optionTitle,
                 selection = [],
                 match,
-                count;
+                count,
+                clone;
 
               if(isMultiple && $attrs.selectedTextFormat === 'count') {
                 count = 1;
@@ -942,12 +943,14 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
                 dropdownToggle.removeClass('show-special-title');
                 // either single or multiple selection will show the only selected content.
                 filterOption.empty();
-                filterOption.append(selection[0]);
+                clone = $compile (selection[0])($scope);
+                filterOption.append(clone);
               } else {
                 dropdownToggle.removeClass('show-special-title');
                 filterOption.empty();
                 for(index = 0; index < selection.length; index++) {
-                  filterOption.append(selection[index]);
+                  clone = $compile (selection[index])($scope);
+                  filterOption.append(clone);
                   if(index < selection.length -1) {
                     filterOption.append(document.createTextNode(', '));
                   }


### PR DESCRIPTION
When option links contain custom content with some added expressions or directives (e.g. ng-style or ng-class) the button should also copy the behavior.