### PR TITLE
Extremely improve the initial load of dropdown

### DIFF
--- a/src/nya-bs-select.js
+++ b/src/nya-bs-select.js
@@ -673,12 +673,9 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
           }
 
           // focus on selected element
-          for(var i = 0; i < dropdownMenu.children().length; i++) {
-            var childElement = dropdownMenu.children().eq(i);
-            if (!childElement.hasClass('not-match') && childElement.hasClass('selected')) {
-              return dropdownMenu.children().eq(i)[0];
-            }
-          }
+          var match = dropdownMenu[0].querySelector('.selected:not(.not-match)');
+            if (match)
+                return match;
 
           if(firstLiElement.hasClass('nya-bs-option') && !firstLiElement.hasClass('disabled') && !firstLiElement.hasClass('not-match')) {
             return firstLiElement[0];

--- a/src/nya-bs-select.js
+++ b/src/nya-bs-select.js
@@ -663,6 +663,19 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
             }
           }
         }
+        
+        function supportsSelector(selector) {
+          var el = document.createElement('div');
+          el.innerHTML = ['&shy;', '<style>', selector, '{}', '</style>'].join('');
+          el = document.body.appendChild(el);
+          var style = el.getElementsByTagName('style')[0];
+            if (style && style.sheet && style.sheet.rules && style.sheet.cssRules) {
+              var ret = !!(style.sheet.rules || style.sheet.cssRules)[0];
+              document.body.removeChild(el);
+              return ret;
+            }
+          return false;
+        }
 
         function findFocus(fromFirst) {
           var firstLiElement;
@@ -673,7 +686,7 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
           }
 
           // focus on selected element
-          if (document.addEventListener) {
+          if (supportsSelector(".selected:not(.not-match)")) {
             var match = dropdownMenu[0].querySelector('.selected:not(.not-match)');
               if (match)
                   return match;

--- a/src/nya-bs-select.js
+++ b/src/nya-bs-select.js
@@ -673,9 +673,20 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
           }
 
           // focus on selected element
-          var match = dropdownMenu[0].querySelector('.selected:not(.not-match)');
-            if (match)
-                return match;
+          if (document.addEventListener) {
+            var match = dropdownMenu[0].querySelector('.selected:not(.not-match)');
+              if (match)
+                  return match;
+          }
+          else {
+            // Fallback for IE8 users
+            for(var i = 0; i < dropdownMenu.children().length; i++) {
+              var childElement = dropdownMenu.children().eq(i);
+              if (!childElement.hasClass('not-match') && childElement.hasClass('selected')) {
+                return dropdownMenu.children().eq(i)[0];
+              }
+            }
+          }
 
           if(firstLiElement.hasClass('nya-bs-option') && !firstLiElement.hasClass('disabled') && !firstLiElement.hasClass('not-match')) {
             return firstLiElement[0];


### PR DESCRIPTION
When a large number of items are used in the dropdown everything is traversed to find to one to highlight, this fix will directly return the first selected option without enumeration.