### PR TITLE
Clear Live-Search

### DIFF
--- a/src/nya-bs-select.js
+++ b/src/nya-bs-select.js
@@ -342,6 +342,28 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
         };
         $document.on('click', outClick);
 
+        function reset_search() {
+          searchBox.children().eq(0)[0].value = "";
+          var options = dropdownMenu.children(),
+              length = options.length,
+              index,
+              option,
+              nyaBsOptionNode;
+            for(index = 0; index < length; index++) {
+              option = options.eq(index);
+              if(option.hasClass('nya-bs-option')) {
+                option.removeClass('not-match');
+              }
+            }
+            noSearchResult.removeClass('show');
+            nyaBsOptionNode = findFocus(true);
+
+            if(nyaBsOptionNode) {
+                options.removeClass('active');
+                jqLite(nyaBsOptionNode).addClass('active');
+            }
+        }
+        
         console.log(dropdownToggle[0]==$element.find('button').eq(0)[0]);
 
         dropdownToggle.on('blur', function() {
@@ -356,6 +378,7 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
             calcMenuSize();
           }
           if($attrs.liveSearch === 'true' && $element.hasClass('open')) {
+            reset_search();
             searchBox.children().eq(0)[0].focus();
             nyaBsOptionNode = findFocus(true);
             if(nyaBsOptionNode) {

--- a/test/spec/live-search-feature.js
+++ b/test/spec/live-search-feature.js
@@ -73,4 +73,67 @@ describe('features about live search related, etc;', function() {
     check();
   });
 
+ it('should clear live-search', function() {
+    // get amount of available li
+    function get_amount() {
+      var list = selectElement.find('ul').children();
+      var i, k, length = list.length,
+          liElement,
+          classList,
+          check,
+          counter = 0;
+      for(i = 0; i < length; i++) {
+        liElement = list.eq(i);
+        if(liElement.hasClass('nya-bs-option')) {
+          classList = liElement[0].classList;
+          check = false;
+          for(k = 0; k < classList.length; k++){
+            if(classList[k] === 'not-match'){
+                check = true;
+            }
+          }
+          if(check === false){
+            counter++;
+          }
+        }
+      }
+      return counter;
+    }
+
+    // string array
+    $scope.options = options;
+    $scope.model = [];
+    $scope.$digest();
+    var selectElement = angular.element('<ol class="nya-bs-select" ng-model="model" live-search="true">' +
+                                        '<li nya-bs-option="option in options">' +
+                                        '<a>{{option}}</a>' +
+                                        '</li>' +
+                                        '</ol>');
+    $compile(selectElement)($scope);
+
+    $scope.$digest();
+    //open dropdown
+    selectElement.find('button')[0].click();
+    //get amount of options
+	  var before_change = get_amount(selectElement, 'amount');
+    //set live-search
+    selectElement.find('input').val('o');
+    //trigger live-search
+    selectElement.find('input').triggerHandler('input');
+    //trigger digest cycle
+    $scope.$digest();
+    //check if value is set
+    expect(selectElement.find('input').val()).toBe('o');
+	  //check amount of options vs new amount
+    expect(get_amount(selectElement, 'amount')).not.toBe(before_change);
+    //close dropdown
+    selectElement.find('button')[0].click();
+    //open dropdown
+    selectElement.find('button')[0].click();
+    //check if value is empty
+    expect(selectElement.find('input').val()).toBe('');
+    //check amount of options vs new amount
+    expect(get_amount(selectElement, 'amount')).toBe(before_change);
+  });
+  
 });


### PR DESCRIPTION
Hello,

like in #175 requested this will clear the Live-Search but instead of clearing it after a selection it will be cleared when the dropdown will be opened.
I think @vasilvalkov and me aren't the only one that want this "feature". 
I'm beware of the fact that you don't want to add new features because this repository is in maintenance state and that this "feature" is "Not desired" like you said but i thought i just give it a shot.

