### PR TITLE
Clear Live-Search with key

### DIFF
--- a/src/nya-bs-select.js
+++ b/src/nya-bs-select.js
@@ -550,6 +550,7 @@ nyaBsSelect.directive('nyaBsSelect', ['$parse', '$document', '$timeout', '$compi
 
               // if live search enabled. give focus to search box.
               if($attrs.liveSearch === 'true') {
+                reset_search();
                 searchBox.children().eq(0)[0].focus();
                 // find the focusable node but we will use active
                 nyaBsOptionNode = findFocus(true);


### PR DESCRIPTION
The live search wasn't cleared if the dropdown was opened with a key, like the enter button.